### PR TITLE
option to not start processors after update

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ usage: java -jar nifi-deploy-config-1.1.3.jar [OPTIONS]
  -user <arg>               user name for access via username/password, then password is mandatory
  -accessFromTicket         Access via Kerberos ticket exchange / SPNEGO negotiation
  -noVerifySsl              turn off ssl verification certificat
+ -noStartProcessors        turn off auto start of the processors after update of the config
 ```
 
 Requirement : *You must have java 8 or higher installed on your machine*

--- a/src/main/java/com/github/hermannpencole/nifi/config/Main.java
+++ b/src/main/java/com/github/hermannpencole/nifi/config/Main.java
@@ -58,6 +58,7 @@ public class Main {
             options.addOption("password", true, "password for access via username/password, then user is mandatory");
             options.addOption("accessFromTicket", false, "Access via Kerberos ticket exchange / SPNEGO negotiation");
             options.addOption("noVerifySsl", false, "turn off ssl verification certificat");
+            options.addOption("noStartProcessors", false, "turn off auto start of the processors after update of the config");
 
             // parse the command line arguments
             CommandLine cmd = commandLineParser.parse(options, args);
@@ -100,7 +101,7 @@ public class Main {
                 if ("updateConfig".equals(cmd.getOptionValue("m"))) {
                     //Get an instance of the bean from the context
                     UpdateProcessorService processorService = injector.getInstance(UpdateProcessorService.class);
-                    processorService.updateByBranch(branchList, fileConfiguration);
+                    processorService.updateByBranch(branchList, fileConfiguration, cmd.hasOption("noStartProcessors"));
                     LOG.info("The group configuration {} is updated with the file {}.", branch, fileConfiguration);
                 } else if ("extractConfig".equals(cmd.getOptionValue("m"))) {
                     //Get an instance of the bean from the context

--- a/src/main/java/com/github/hermannpencole/nifi/config/service/UpdateProcessorService.java
+++ b/src/main/java/com/github/hermannpencole/nifi/config/service/UpdateProcessorService.java
@@ -50,7 +50,7 @@ public class UpdateProcessorService {
      * @throws URISyntaxException
      * @throws ApiException
      */
-    public void updateByBranch(List<String> branch, String fileConfiguration) throws IOException, ApiException {
+    public void updateByBranch(List<String> branch, String fileConfiguration, boolean optionNoStartProcessors) throws IOException, ApiException {
         File file = new File(fileConfiguration);
         if (!file.exists()) {
             throw new FileNotFoundException("Repository " + file.getName() + " is empty or doesn't exist");
@@ -74,9 +74,11 @@ public class UpdateProcessorService {
             String clientId = flowapi.generateClientId();
             updateComponent(configuration, componentSearch, clientId);
 
-            //Run all nifi processors
-            processGroupService.setState(componentSearch.getProcessGroupFlow().getId(), ScheduleComponentsEntity.StateEnum.RUNNING);
-            LOG.info(Arrays.toString(branch.toArray()) + " is running");
+            if (!optionNoStartProcessors) {
+                //Run all nifi processors
+                processGroupService.setState(componentSearch.getProcessGroupFlow().getId(), ScheduleComponentsEntity.StateEnum.RUNNING);
+                LOG.info(Arrays.toString(branch.toArray()) + " is running");
+            }
         } finally {
             LOG.debug("updateByBranch end");
         }

--- a/src/test/java/com/github/hermannpencole/nifi/config/MainTest.java
+++ b/src/test/java/com/github/hermannpencole/nifi/config/MainTest.java
@@ -113,7 +113,7 @@ public class MainTest {
         Mockito.when(Guice.createInjector()).thenReturn(injector);
 
         Main.main(new String[]{"-nifi","http://localhost:8080/nifi-api","-branch","\"root>N2\"","-conf","adr","-m","updateConfig","-user","user","-password","password"});
-        verify(updateProcessorServiceMock).updateByBranch(Arrays.asList("root","N2"), "adr");
+        verify(updateProcessorServiceMock).updateByBranch(Arrays.asList("root","N2"), "adr",false);
     }
 
     @Test

--- a/src/test/java/com/github/hermannpencole/nifi/config/service/UpdateProcessorServiceTest.java
+++ b/src/test/java/com/github/hermannpencole/nifi/config/service/UpdateProcessorServiceTest.java
@@ -43,7 +43,7 @@ public class UpdateProcessorServiceTest {
     @Test(expected = FileNotFoundException.class)
     public void updateFileNotExitingBranchTest() throws ApiException, IOException, URISyntaxException {
         List<String> branch = Arrays.asList("root", "elt1");
-        updateProcessorService.updateByBranch(branch, "not existing");
+        updateProcessorService.updateByBranch(branch, "not existing", false);
     }
 
     @Test
@@ -63,7 +63,7 @@ public class UpdateProcessorServiceTest {
                 .getProcessors().add(TestUtils.createProcessorEntity("idProc2", "nameProc2"));
         when(flowapiMock.getFlow(subGroupResponse.getProcessGroupFlow().getId())).thenReturn(subGroupResponse);
 
-        updateProcessorService.updateByBranch(branch, getClass().getClassLoader().getResource("mytest1.json").getPath());
+        updateProcessorService.updateByBranch(branch, getClass().getClassLoader().getResource("mytest1.json").getPath(), false);
 
         verify(processorsApiMock, times(2)).updateProcessor(any(), any());
         verify(processorsApiMock).updateProcessor(eq("idProc"), any());
@@ -84,7 +84,7 @@ public class UpdateProcessorServiceTest {
         when(processGroupServiceMock.changeDirectory(branch)).thenReturn(Optional.of(response));
         when(flowapiMock.getFlow(response.getProcessGroupFlow().getId())).thenReturn(response);
 
-        updateProcessorService.updateByBranch(branch, getClass().getClassLoader().getResource("mytestAutoTerminateRelationShip.json").getPath());
+        updateProcessorService.updateByBranch(branch, getClass().getClassLoader().getResource("mytestAutoTerminateRelationShip.json").getPath(), false);
 
         verify(processorsApiMock, times(1)).updateProcessor(any(), any());
         ArgumentCaptor<ProcessorEntity> processorEntity = ArgumentCaptor.forClass(ProcessorEntity.class);
@@ -106,7 +106,7 @@ public class UpdateProcessorServiceTest {
         when(flowapiMock.getFlow(response.getProcessGroupFlow().getId())).thenReturn(response);
 
         when(processorsApiMock.updateProcessor(any(), any())).thenThrow(new ApiException());
-        updateProcessorService.updateByBranch(branch, getClass().getClassLoader().getResource("mytest1.json").getPath());
+        updateProcessorService.updateByBranch(branch, getClass().getClassLoader().getResource("mytest1.json").getPath(), false);
 
     }
 


### PR DESCRIPTION
default behaviour of the deploy of a template is that all processors are stopped. i wanted to extend this behaviour to the deploy of the config so that we can update but keep all processors stopped