### PR TITLE
Added 'enableDebugMode' flag to activate library API debug logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
+# Generated content
 /target
 /configure-nifi.iml
-/.idea
 /nifi-deploy-config.iml
 /dependency-reduced-pom.xml
+# IDE files
+/.idea
+/.settings
+/.project
+/.classpath

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 
-# Deploy and configure Template on Nifi 
+# Deploy and configure Template on Nifi
 [![Maven Central](https://img.shields.io/maven-central/v/com.github.hermannpencole/nifi-deploy-config.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.hermannpencole/nifi-deploy-config)
 [![Build Status](https://travis-ci.org/hermannpencole/nifi-config.svg?branch=master)](https://travis-ci.org/hermannpencole/nifi-config/)
 [![codecov](https://codecov.io/gh/hermannpencole/nifi-config/branch/master/graph/badge.svg)](https://codecov.io/gh/hermannpencole/nifi-config)
@@ -34,6 +34,7 @@ usage: java -jar nifi-deploy-config-1.1.5.jar [OPTIONS]
  -accessFromTicket         Access via Kerberos ticket exchange / SPNEGO negotiation
  -noVerifySsl              turn off ssl verification certificat
  -noStartProcessors        turn off auto start of the processors after update of the config
+ -enableDebugMode          turn on debugging mode of the underlying API library
 ```
 
 Requirement : *You must have java 8 or higher installed on your machine*
@@ -42,7 +43,7 @@ Requirement : *You must have java 8 or higher installed on your machine*
 
 ### Prepare your nifi development
 
-1 ) Create a template on nifi : 
+1 ) Create a template on nifi :
 
 with this rule : each processor and each controller in a process group **must** have a unique name.
 
@@ -145,8 +146,8 @@ sample :
 		"comments": "",
 		"lossTolerant": false
 	  }
-	} 
-      
+	}
+
   ],
   "controllerServices": [
     {
@@ -246,7 +247,7 @@ Delete properties when this is null
 
 Start (one by one ?) processor and get error if there is
 
-All idea are welcome. 
+All idea are welcome.
 
 # Troubleshooting
 

--- a/src/main/java/com/github/hermannpencole/nifi/config/Main.java
+++ b/src/main/java/com/github/hermannpencole/nifi/config/Main.java
@@ -64,6 +64,7 @@ public class Main {
             options.addOption("accessFromTicket", false, "Access via Kerberos ticket exchange / SPNEGO negotiation");
             options.addOption("noVerifySsl", false, "turn off ssl verification certificat");
             options.addOption("noStartProcessors", false, "turn off auto start of the processors after update of the config");
+            options.addOption("enableDebugMode", false, "turn on debug mode");
 
             // parse the command line arguments
             CommandLine cmd = commandLineParser.parse(options, args);
@@ -99,7 +100,7 @@ public class Main {
                     throw new ConfigException("The branch address must begin with the element 'root' ( sample : root > branch > sub-branch)");
                 }
 
-                setConfiguration(addressNifi, !cmd.hasOption("noVerifySsl"));
+                setConfiguration(addressNifi, !cmd.hasOption("noVerifySsl"), cmd.hasOption("enableDebugMode"));
                 Injector injector = Guice.createInjector(new AbstractModule() {
                     protected void configure() {
                         bind(Integer.class).annotatedWith(Names.named("timeout")).toInstance(timeout);
@@ -143,8 +144,9 @@ public class Main {
     }
 
 
-    public static void setConfiguration(String basePath, boolean verifySsl) throws ApiException {
+    public static void setConfiguration(String basePath, boolean verifySsl, boolean debugging) throws ApiException {
         ApiClient client = new ApiClient().setBasePath(basePath).setVerifyingSsl(verifySsl);
+        client.setDebugging(debugging);
         Configuration.setDefaultApiClient(client);
     }
 }


### PR DESCRIPTION
Simple change: the nifi-config now allows to specify "enableDebugMode" in order to put the ApiClient in debugging mode. This is particularly useful (at least here) to understand what's going on when some API calls appear to not be working.