### PR TITLE
Provide a way to connect components between process groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ sample :
     {
       "name": "front_end_1",
       "source": "root > front_end > front_end_1",
-      "destination": "root > front_end > back_end_1"
+      "destination": "root > back_end > back_end_1"
     }
   ],
   "name": "testController"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Update, Extract Nifi Configuration
 
-Deploy, undeploy template
+Deploy, undeploy, connect template
 
 ## Which version
 
@@ -93,6 +93,8 @@ You can find all properties in your extraction file. Now just configure it with 
 
 Configuration work with the name, remember that each processor in a group **must** have a unique name.
 
+It is also possible to create connections between process groups by adding a `connections` JSON element to the configuration. The shortest route between the two process groups will be selected, with output and input ports named according to the connection's name used automatically, and created if they do not already exist. Note that it is only possible to connect to input and output ports, so this functionality is typically best used by including an input or output port already wired in to the template that is named the same as the connection.
+
 sample :
 ```json
 {  
@@ -140,7 +142,6 @@ sample :
 		"lossTolerant": false
 	  }
 	}
-
   ],
   "controllerServices": [
     {
@@ -151,6 +152,13 @@ sample :
 		"Password": "********",
         "Max Total Connections": "3"
       }
+    }
+  ],
+  "connections": [
+    {
+      "name": "front_end_1",
+      "source": "root > front_end > front_end_1",
+      "destination": "root > front_end > back_end_1"
     }
   ],
   "name": "testController"

--- a/src/main/java/com/github/hermannpencole/nifi/config/Main.java
+++ b/src/main/java/com/github/hermannpencole/nifi/config/Main.java
@@ -127,6 +127,8 @@ public class Main {
                     //Get an instance of the bean from the context
                     UpdateProcessorService processorService = injector.getInstance(UpdateProcessorService.class);
                     processorService.updateByBranch(branchList, fileConfiguration, cmd.hasOption("noStartProcessors"));
+                    CreateRouteService routeService = injector.getInstance(CreateRouteService.class);
+                    routeService.createRoutes(fileConfiguration, cmd.hasOption("noStartProcessors"));
                     LOG.info("The group configuration {} is updated with the file {}.", branch, fileConfiguration);
                 } else if ("extractConfig".equals(cmd.getOptionValue("m"))) {
                     //Get an instance of the bean from the context

--- a/src/main/java/com/github/hermannpencole/nifi/config/model/RouteConnectionEntity.java
+++ b/src/main/java/com/github/hermannpencole/nifi/config/model/RouteConnectionEntity.java
@@ -1,0 +1,70 @@
+package com.github.hermannpencole.nifi.config.model;
+
+import com.google.gson.annotations.SerializedName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RouteConnectionEntity {
+
+    /**
+     * The logger.
+     */
+    private final static Logger LOG = LoggerFactory.getLogger(RouteConnectionEntity.class);
+
+    @SerializedName("name")
+    private String name;
+
+    @SerializedName("source")
+    private String source;
+
+    @SerializedName("destination")
+    private String destination;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public List<String> getSourceList() {
+        return validateBranch(splitBranch(source));
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    public String getDestination() {
+        return destination;
+    }
+
+    public List<String> getDestinationList() {
+        return validateBranch(splitBranch(destination));
+    }
+
+    public void setDestination(String destination) {
+        this.destination = destination;
+    }
+
+    private List<String> splitBranch(String branch) {
+        LOG.info("Parsing branch '{}' for connection named '{}'", branch, name);
+        return Arrays.stream(branch.split(">")).map(String::trim).collect(Collectors.toList());
+    }
+
+    private List<String> validateBranch(List<String> branch) {
+        if (!branch.get(0).equals("root")) {
+            throw new ConfigException("The branch address must begin with the element 'root' ( sample : root > branch > sub-branch)");
+        }
+        return branch;
+    }
+}

--- a/src/main/java/com/github/hermannpencole/nifi/config/model/RouteConnectionsEntity.java
+++ b/src/main/java/com/github/hermannpencole/nifi/config/model/RouteConnectionsEntity.java
@@ -1,0 +1,20 @@
+package com.github.hermannpencole.nifi.config.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RouteConnectionsEntity {
+
+    @SerializedName("connections")
+    private List<RouteConnectionEntity> connections = new ArrayList<>();
+
+    public List<RouteConnectionEntity> getConnections() {
+        return connections;
+    }
+
+    public void setConnections(List<RouteConnectionEntity> connections) {
+        this.connections = connections;
+    }
+}

--- a/src/main/java/com/github/hermannpencole/nifi/config/service/CreateRouteService.java
+++ b/src/main/java/com/github/hermannpencole/nifi/config/service/CreateRouteService.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
 
 import static com.github.hermannpencole.nifi.config.utils.FunctionUtils.findByComponentName;
 
-public final class CreateRouteService {
+public class CreateRouteService {
 
     /**
      * The logger.

--- a/src/main/java/com/github/hermannpencole/nifi/config/service/CreateRouteService.java
+++ b/src/main/java/com/github/hermannpencole/nifi/config/service/CreateRouteService.java
@@ -1,0 +1,291 @@
+package com.github.hermannpencole.nifi.config.service;
+
+import com.github.hermannpencole.nifi.config.model.ConfigException;
+import com.github.hermannpencole.nifi.config.utils.FunctionUtils;
+import com.github.hermannpencole.nifi.swagger.ApiException;
+import com.github.hermannpencole.nifi.swagger.client.FlowApi;
+import com.github.hermannpencole.nifi.swagger.client.ProcessGroupsApi;
+import com.github.hermannpencole.nifi.swagger.client.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.*;
+import java.util.stream.Stream;
+
+public class CreateRouteService {
+
+    /**
+     * The logger.
+     */
+    private final static Logger LOG = LoggerFactory.getLogger(CreateRouteService.class);
+
+    private String getClientId() {
+        if (clientId == null) {
+            clientId = flowapi.generateClientId();
+        }
+        return clientId;
+    }
+
+    private String clientId;
+
+    @Inject
+    private FlowApi flowapi;
+
+    @Inject
+    private ProcessGroupsApi processGroupsApi;
+
+    private Optional<PortEntity> findPortEntityByName(Stream<PortEntity> portEntities, String name) {
+        return portEntities.filter(item -> item.getComponent().getName().trim().equals(name.trim())).findFirst();
+    }
+
+    private PortDTO.TypeEnum matchConnectableTypeToPortType(ConnectableDTO.TypeEnum connectableType) {
+        switch (connectableType) {
+            case INPUT_PORT:
+                return PortDTO.TypeEnum.INPUT_PORT;
+            case OUTPUT_PORT:
+                return PortDTO.TypeEnum.OUTPUT_PORT;
+            default:
+                throw new ConfigException("Cannot convert " + connectableType + " to PortDTO");
+        }
+    }
+
+    private ConnectableDTO.TypeEnum matchPortTypeToConnectableType(PortDTO.TypeEnum portType) {
+        switch (portType) {
+            case INPUT_PORT:
+                return ConnectableDTO.TypeEnum.INPUT_PORT;
+            case OUTPUT_PORT:
+                return ConnectableDTO.TypeEnum.OUTPUT_PORT;
+            default:
+                throw new ConfigException("Cannot convert " + portType + " to ConnectableDTO");
+        }
+    }
+
+    /**
+     * Creates an input or output port.
+     *
+     * @param processGroupId GUID of the process group in which to create the port
+     * @param name           The name of the port
+     * @param type           Whether to create an input or an output port
+     * @return A data transfer object representative of the state of the created port
+     */
+    private PortEntity createPort(String processGroupId, String name, PortDTO.TypeEnum type) {
+        PortEntity portEntity = new PortEntity();
+        portEntity.setRevision(new RevisionDTO());
+        portEntity.setComponent(new PortDTO());
+        portEntity.getRevision().setVersion(0L);
+        portEntity.getRevision().setClientId(getClientId());
+        portEntity.getComponent().setName(name);
+        switch (type) {
+            case INPUT_PORT:
+                return processGroupsApi.createInputPort(processGroupId, portEntity);
+            case OUTPUT_PORT:
+                return processGroupsApi.createOutputPort(processGroupId, portEntity);
+        }
+        throw new ConfigException(String.format("Couldn't create port '{}'", name));
+    }
+
+    private ConnectableDTO createConnectableDTOFromPort(PortEntity port) {
+        ConnectableDTO connectableDTO = new ConnectableDTO();
+        connectableDTO.setGroupId(port.getComponent().getParentGroupId());
+        connectableDTO.setName(port.getComponent().getName());
+        connectableDTO.setId(port.getComponent().getId());
+        connectableDTO.setType(matchPortTypeToConnectableType(port.getComponent().getType()));
+
+        return connectableDTO;
+    }
+
+    private ConnectableDTO findConnectableComponent(
+            final ProcessGroupFlowEntity flowEntity,
+            final String componentName) {
+        // Ports
+        Optional<PortEntity> port = findPortEntityByName(
+                flowEntity.getProcessGroupFlow().getFlow().getOutputPorts().stream(),
+                componentName);
+        if (port.isPresent()) {
+            return createConnectableDTOFromPort(port.get());
+        }
+        port = findPortEntityByName(
+                flowEntity.getProcessGroupFlow().getFlow().getInputPorts().stream(),
+                componentName);
+        if (port.isPresent()) {
+            return createConnectableDTOFromPort(port.get());
+        }
+
+        return null;
+    }
+
+    private ProcessGroupFlowEntity advanceToNextProcessGroup(
+            String processGroupName,
+            ProcessGroupFlowEntity flowEntity) {
+        Optional<ProcessGroupEntity> flowEntityChild = FunctionUtils.findByComponentName(
+                flowEntity.getProcessGroupFlow().getFlow().getProcessGroups(),
+                processGroupName);
+        if (!flowEntityChild.isPresent()) {
+            throw new ConfigException("Couldn't find process group '" + processGroupName + "'");
+        }
+        flowEntity = flowapi.getFlow(flowEntityChild.get().getId());
+        return flowEntity;
+    }
+
+    private ConnectableDTO createOrFindPort(
+            String destinationInputPort,
+            ConnectableDTO.TypeEnum connectableType,
+            ProcessGroupFlowEntity flowEntity, String processGroupName) {
+        ConnectableDTO connectableDTO = findConnectableComponent(flowEntity, destinationInputPort);
+        if (connectableDTO != null && connectableDTO.getType() == connectableType) {
+            return connectableDTO;
+        }
+        if (connectableDTO == null) {
+            return createConnectableDTOFromPort(createPort(
+                    flowEntity.getProcessGroupFlow().getId(),
+                    destinationInputPort,
+                    matchConnectableTypeToPortType(connectableType)));
+        }
+        throw new ConfigException("'" + destinationInputPort + "' in '" + processGroupName
+                + "' is not a " + connectableType);
+    }
+
+    private String determineConnectionLocation(
+            ConnectableDTO source,
+            ConnectableDTO destination) {
+        switch (source.getType()) {
+            case OUTPUT_PORT:
+                switch (destination.getType()) {
+                    case OUTPUT_PORT:
+                        return destination.getGroupId();
+                    case INPUT_PORT:
+                        return flowapi.getFlow(source.getGroupId()).getProcessGroupFlow().getParentGroupId();
+                }
+            case INPUT_PORT:
+                switch (destination.getType()) {
+                    case OUTPUT_PORT:
+                        return source.getGroupId();
+                    case INPUT_PORT:
+                        return source.getGroupId();
+                }
+        }
+
+        throw new ConfigException("Creating connections between types other than local ports not supported");
+    }
+
+    private ConnectionEntity createConnectionEntity(
+            ConnectableDTO source,
+            ConnectableDTO dest) {
+        ConnectionEntity connectionEntity = new ConnectionEntity();
+        connectionEntity.setRevision(new RevisionDTO());
+        connectionEntity.getRevision().setVersion(0L);
+        connectionEntity.getRevision().setClientId(getClientId());
+        connectionEntity.setComponent(new ConnectionDTO());
+        connectionEntity.getComponent().setSource(source);
+        connectionEntity.getComponent().setDestination(dest);
+
+        return connectionEntity;
+    }
+
+    private boolean connectionExists(
+            final Stream<ConnectionEntity> connectionEntities,
+            final ConnectionEntity connectionEntity) {
+        return connectionEntities.anyMatch(item ->
+                item.getComponent().getSource().getGroupId().equals(
+                        connectionEntity.getComponent().getSource().getGroupId())
+                        && item.getComponent().getSource().getId().equals(
+                        connectionEntity.getComponent().getSource().getId())
+                        && item.getComponent().getSource().getName().trim().equals(
+                        connectionEntity.getComponent().getSource().getName().trim())
+                        && item.getComponent().getSource().getType().equals(
+                        connectionEntity.getComponent().getSource().getType())
+                        && item.getComponent().getDestination().getGroupId().equals(
+                        connectionEntity.getComponent().getDestination().getGroupId())
+                        && item.getComponent().getDestination().getId().equals(
+                        connectionEntity.getComponent().getDestination().getId())
+                        && item.getComponent().getDestination().getName().trim().equals(
+                        connectionEntity.getComponent().getDestination().getName().trim())
+                        && item.getComponent().getDestination().getType().equals(
+                        connectionEntity.getComponent().getDestination().getType())
+        );
+    }
+
+    private List<ConnectableDTO> createPorts(
+            final ListIterator<String> branch,
+            final String destinationInputPort,
+            final ConnectableDTO.TypeEnum connectableType)
+            throws ApiException {
+        List<ConnectableDTO> connectableDTOs = new ArrayList<>();
+        int mergeLevel = branch.nextIndex();
+        boolean createPorts = false;
+
+        // Traverse back up to root and start examining the flow
+        while (branch.hasPrevious()) branch.previous();
+        ProcessGroupFlowEntity flowEntity = flowapi.getFlow("root");
+        branch.next();
+
+        // Traverse back down the process group hierarchy
+        // Create output ports from the position in the hierarchy where the branch iterator initially pointed
+        while (branch.hasNext()) {
+            if (branch.nextIndex() == mergeLevel) {
+                createPorts = true;
+            }
+            String processGroupName = branch.next();
+            flowEntity = advanceToNextProcessGroup(processGroupName, flowEntity);
+            if (createPorts) {
+                connectableDTOs.add(
+                        createOrFindPort(destinationInputPort, connectableType, flowEntity, processGroupName));
+            }
+        }
+
+        return connectableDTOs;
+    }
+
+    private void createConnections(final ListIterator<ConnectableDTO> connectables) {
+        ConnectableDTO current;
+        ConnectableDTO next = connectables.next();
+        while (connectables.hasNext()) {
+            current = next;
+            next = connectables.next();
+
+            ProcessGroupFlowEntity flowEntity = flowapi.getFlow(determineConnectionLocation(current, next));
+
+            ConnectionEntity connectionEntity = createConnectionEntity(current, next);
+
+            if (!connectionExists(
+                    flowEntity.getProcessGroupFlow().getFlow().getConnections().stream(),
+                    connectionEntity)) {
+                processGroupsApi.createConnection(flowEntity.getProcessGroupFlow().getId(), connectionEntity);
+            }
+        }
+    }
+
+    /**
+     * Create a route in NiFi composed of ports and connections.
+     *
+     * @param sourcePath           Path to the process group from which to create the route
+     * @param destinationPath      Path to the process group to which to create the route
+     * @param destinationInputPort Name of ports created along the route
+     */
+    public void createRoute(
+            final List<String> sourcePath,
+            final List<String> destinationPath,
+            final String destinationInputPort) {
+        ListIterator<String> source = sourcePath.listIterator();
+        ListIterator<String> destination = destinationPath.listIterator();
+
+        // Find the lowest level in the process group hierarchy where the route can pass between two process groups
+        while (!source.next().equals(destination.next())) ;
+
+        // Traverse the source branch, creating output ports down the hierarchy
+        List<ConnectableDTO> sourceConnectables
+                = createPorts(source, destinationInputPort, ConnectableDTO.TypeEnum.OUTPUT_PORT);
+        // Reverse the sequence of the output ports as the connections should point up the hierarchy
+        Collections.reverse(sourceConnectables);
+
+        // Traverse the destination branch, creating input ports up the hierarchy
+        List<ConnectableDTO> destinationConnectables
+                = createPorts(destination, destinationInputPort, ConnectableDTO.TypeEnum.INPUT_PORT);
+
+        // Stitch the two lists of connectables together
+        List<ConnectableDTO> route = new ArrayList<>(sourceConnectables);
+        route.addAll(destinationConnectables);
+        createConnections(route.listIterator());
+    }
+}

--- a/src/main/java/com/github/hermannpencole/nifi/config/service/CreateRouteService.java
+++ b/src/main/java/com/github/hermannpencole/nifi/config/service/CreateRouteService.java
@@ -355,6 +355,13 @@ public final class CreateRouteService {
         }
     }
 
+    /**
+     * Create routes described by configuration.
+     *
+     * @param fileConfiguration       Configuration file describing connections
+     * @param optionNoStartProcessors Whether or not to start ports created along the route
+     * @throws IOException If repository file cannot be found
+     */
     public void createRoutes(String fileConfiguration, boolean optionNoStartProcessors) throws IOException {
         File file = new File(fileConfiguration);
         if (!file.exists()) {

--- a/src/main/java/com/github/hermannpencole/nifi/config/service/CreateRouteService.java
+++ b/src/main/java/com/github/hermannpencole/nifi/config/service/CreateRouteService.java
@@ -3,7 +3,6 @@ package com.github.hermannpencole.nifi.config.service;
 import com.github.hermannpencole.nifi.config.model.ConfigException;
 import com.github.hermannpencole.nifi.config.model.RouteConnectionEntity;
 import com.github.hermannpencole.nifi.config.model.RouteConnectionsEntity;
-import com.github.hermannpencole.nifi.config.utils.FunctionUtils;
 import com.github.hermannpencole.nifi.swagger.ApiException;
 import com.github.hermannpencole.nifi.swagger.client.FlowApi;
 import com.github.hermannpencole.nifi.swagger.client.InputPortsApi;
@@ -20,6 +19,8 @@ import java.io.*;
 import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
+
+import static com.github.hermannpencole.nifi.config.utils.FunctionUtils.findByComponentName;
 
 public final class CreateRouteService {
 
@@ -132,7 +133,7 @@ public final class CreateRouteService {
     private ProcessGroupFlowEntity advanceToNextProcessGroup(
             final String processGroupName,
             final ProcessGroupFlowEntity flowEntity) {
-        Optional<ProcessGroupEntity> flowEntityChild = FunctionUtils.findByComponentName(
+        Optional<ProcessGroupEntity> flowEntityChild = findByComponentName(
                 flowEntity.getProcessGroupFlow().getFlow().getProcessGroups(),
                 processGroupName);
         if (!flowEntityChild.isPresent()) {

--- a/src/main/java/com/github/hermannpencole/nifi/config/service/ProcessGroupService.java
+++ b/src/main/java/com/github/hermannpencole/nifi/config/service/ProcessGroupService.java
@@ -1,5 +1,6 @@
 package com.github.hermannpencole.nifi.config.service;
 
+import com.github.hermannpencole.nifi.config.utils.FunctionUtils;
 import com.github.hermannpencole.nifi.swagger.ApiException;
 import com.github.hermannpencole.nifi.swagger.client.FlowApi;
 import com.github.hermannpencole.nifi.swagger.client.ProcessGroupsApi;
@@ -46,20 +47,13 @@ public class ProcessGroupService {
     public Optional<ProcessGroupFlowEntity> changeDirectory(List<String> branch) throws ApiException {
         ProcessGroupFlowEntity flowEntity = flowapi.getFlow("root");
         for (String processGroupName : branch.subList(1, branch.size())) {
-            Optional<ProcessGroupEntity> flowEntityChild = findByComponentName(flowEntity.getProcessGroupFlow().getFlow().getProcessGroups(), processGroupName);
+            Optional<ProcessGroupEntity> flowEntityChild = FunctionUtils.findByComponentName(flowEntity.getProcessGroupFlow().getFlow().getProcessGroups(), processGroupName);
             if (!flowEntityChild.isPresent()) {
                 return Optional.empty();
             }
             flowEntity = flowapi.getFlow(flowEntityChild.get().getId());
         }
         return Optional.of(flowEntity);
-    }
-
-    //can static => utils
-    public static Optional<ProcessGroupEntity> findByComponentName(List<ProcessGroupEntity> listGroup, String name) {
-        return listGroup.stream()
-                .filter(item -> item.getComponent().getName().trim().equals(name.trim()))
-                .findFirst();
     }
 
     /**
@@ -75,7 +69,7 @@ public class ProcessGroupService {
         //find root
         ProcessGroupFlowEntity flowEntity = flowapi.getFlow("root");
         for (String processGroupName : branch.subList(1, branch.size())) {
-            Optional<ProcessGroupEntity> flowEntityChild = findByComponentName(flowEntity.getProcessGroupFlow().getFlow().getProcessGroups(), processGroupName);
+            Optional<ProcessGroupEntity> flowEntityChild = FunctionUtils.findByComponentName(flowEntity.getProcessGroupFlow().getFlow().getProcessGroups(), processGroupName);
             if (!flowEntityChild.isPresent()) {
                 PositionDTO position = getNextPosition(flowEntity);
                 ProcessGroupEntity created = new ProcessGroupEntity();

--- a/src/main/java/com/github/hermannpencole/nifi/config/service/ProcessGroupService.java
+++ b/src/main/java/com/github/hermannpencole/nifi/config/service/ProcessGroupService.java
@@ -1,6 +1,5 @@
 package com.github.hermannpencole.nifi.config.service;
 
-import com.github.hermannpencole.nifi.config.utils.FunctionUtils;
 import com.github.hermannpencole.nifi.swagger.ApiException;
 import com.github.hermannpencole.nifi.swagger.client.FlowApi;
 import com.github.hermannpencole.nifi.swagger.client.ProcessGroupsApi;
@@ -11,6 +10,8 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.*;
+
+import static com.github.hermannpencole.nifi.config.utils.FunctionUtils.findByComponentName;
 
 /**
  * Class that offer service for process group
@@ -47,7 +48,7 @@ public class ProcessGroupService {
     public Optional<ProcessGroupFlowEntity> changeDirectory(List<String> branch) throws ApiException {
         ProcessGroupFlowEntity flowEntity = flowapi.getFlow("root");
         for (String processGroupName : branch.subList(1, branch.size())) {
-            Optional<ProcessGroupEntity> flowEntityChild = FunctionUtils.findByComponentName(flowEntity.getProcessGroupFlow().getFlow().getProcessGroups(), processGroupName);
+            Optional<ProcessGroupEntity> flowEntityChild = findByComponentName(flowEntity.getProcessGroupFlow().getFlow().getProcessGroups(), processGroupName);
             if (!flowEntityChild.isPresent()) {
                 return Optional.empty();
             }
@@ -69,7 +70,7 @@ public class ProcessGroupService {
         //find root
         ProcessGroupFlowEntity flowEntity = flowapi.getFlow("root");
         for (String processGroupName : branch.subList(1, branch.size())) {
-            Optional<ProcessGroupEntity> flowEntityChild = FunctionUtils.findByComponentName(flowEntity.getProcessGroupFlow().getFlow().getProcessGroups(), processGroupName);
+            Optional<ProcessGroupEntity> flowEntityChild = findByComponentName(flowEntity.getProcessGroupFlow().getFlow().getProcessGroups(), processGroupName);
             if (!flowEntityChild.isPresent()) {
                 PositionDTO position = getNextPosition(flowEntity);
                 ProcessGroupEntity created = new ProcessGroupEntity();
@@ -177,8 +178,8 @@ public class ProcessGroupService {
         while (!connections.isEmpty()) {
             Set<String> destination = new HashSet<>();
             Set<String> source = new HashSet<>();
-            Set<ConnectionEntity> levelConnection= new HashSet<>();
-            for (ConnectionEntity connection: new ArrayList<>(connections)) {
+            Set<ConnectionEntity> levelConnection = new HashSet<>();
+            for (ConnectionEntity connection : new ArrayList<>(connections)) {
                 if (thisLevel.contains(connection.getSourceId())) {
                     source.add(connection.getDestinationId());
                     //remove connection for next use
@@ -194,8 +195,8 @@ public class ProcessGroupService {
             }
             thisLevel = new HashSet<>(source);
             thisLevel.removeAll(destination);
-            Set<ProcessorEntity> levelProcessor= new HashSet<>();
-            for (ProcessorEntity processor : flow.getProcessors()){
+            Set<ProcessorEntity> levelProcessor = new HashSet<>();
+            for (ProcessorEntity processor : flow.getProcessors()) {
                 if (thisLevel.contains(processor.getId())) {
                     levelProcessor.add(processor);
                 }
@@ -224,7 +225,7 @@ public class ProcessGroupService {
         nextPosition.setX(0d);
         nextPosition.setY(0d);
         while (positions.indexOf(nextPosition) != -1) {
-            if(nextPosition.getX() == 800d) {
+            if (nextPosition.getX() == 800d) {
                 nextPosition.setX(0d);
                 nextPosition.setY(nextPosition.getY() + 200);
             } else {

--- a/src/main/java/com/github/hermannpencole/nifi/config/service/UpdateProcessorService.java
+++ b/src/main/java/com/github/hermannpencole/nifi/config/service/UpdateProcessorService.java
@@ -2,6 +2,7 @@ package com.github.hermannpencole.nifi.config.service;
 
 import com.github.hermannpencole.nifi.config.model.ConfigException;
 import com.github.hermannpencole.nifi.config.model.GroupProcessorsEntity;
+import com.github.hermannpencole.nifi.config.utils.FunctionUtils;
 import com.github.hermannpencole.nifi.swagger.ApiException;
 import com.github.hermannpencole.nifi.swagger.client.FlowApi;
 import com.github.hermannpencole.nifi.swagger.client.ProcessorsApi;
@@ -137,7 +138,7 @@ public class UpdateProcessorService {
         FlowDTO flow = componentSearch.getProcessGroupFlow().getFlow();
         configuration.getProcessors().forEach(processorOnConfig -> updateProcessor(flow.getProcessors(), processorOnConfig, clientId));
         for (GroupProcessorsEntity procGroupInConf : configuration.getGroupProcessorsEntity()) {
-            ProcessGroupEntity processorGroupToUpdate = ProcessGroupService.findByComponentName(flow.getProcessGroups(), procGroupInConf.getName())
+            ProcessGroupEntity processorGroupToUpdate = FunctionUtils.findByComponentName(flow.getProcessGroups(), procGroupInConf.getName())
                     .orElseThrow(() -> new ConfigException(("cannot find " + procGroupInConf.getName())));
             updateComponent(procGroupInConf, flowapi.getFlow(processorGroupToUpdate.getId()), clientId);
         }

--- a/src/main/java/com/github/hermannpencole/nifi/config/service/UpdateProcessorService.java
+++ b/src/main/java/com/github/hermannpencole/nifi/config/service/UpdateProcessorService.java
@@ -2,7 +2,6 @@ package com.github.hermannpencole.nifi.config.service;
 
 import com.github.hermannpencole.nifi.config.model.ConfigException;
 import com.github.hermannpencole.nifi.config.model.GroupProcessorsEntity;
-import com.github.hermannpencole.nifi.config.utils.FunctionUtils;
 import com.github.hermannpencole.nifi.swagger.ApiException;
 import com.github.hermannpencole.nifi.swagger.client.FlowApi;
 import com.github.hermannpencole.nifi.swagger.client.ProcessorsApi;
@@ -20,6 +19,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+
+import static com.github.hermannpencole.nifi.config.utils.FunctionUtils.findByComponentName;
 
 /**
  * Class that offer service for nifi processor
@@ -97,7 +98,6 @@ public class UpdateProcessorService {
     }
 
 
-
     /**
      *
      * @param configuration
@@ -138,7 +138,7 @@ public class UpdateProcessorService {
         FlowDTO flow = componentSearch.getProcessGroupFlow().getFlow();
         configuration.getProcessors().forEach(processorOnConfig -> updateProcessor(flow.getProcessors(), processorOnConfig, clientId));
         for (GroupProcessorsEntity procGroupInConf : configuration.getGroupProcessorsEntity()) {
-            ProcessGroupEntity processorGroupToUpdate = FunctionUtils.findByComponentName(flow.getProcessGroups(), procGroupInConf.getName())
+            ProcessGroupEntity processorGroupToUpdate = findByComponentName(flow.getProcessGroups(), procGroupInConf.getName())
                     .orElseThrow(() -> new ConfigException(("cannot find " + procGroupInConf.getName())));
             updateComponent(procGroupInConf, flowapi.getFlow(processorGroupToUpdate.getId()), clientId);
         }
@@ -147,7 +147,8 @@ public class UpdateProcessorService {
     /**
      * update processor configuration with valueToPutInProc
      * at first find id of each processor and in second way update it
-     *  @param processorsList
+     *
+     * @param processorsList
      * @param componentToPutInProc
      * @param clientId
      */
@@ -174,7 +175,7 @@ public class UpdateProcessorService {
             componentToPutInProc.setRestricted(null);//processorToUpdate.getComponent().getRestricted());
             componentToPutInProc.setValidationErrors(processorToUpdate.getComponent().getValidationErrors());
             //remove controller link
-            for ( Map.Entry<String, PropertyDescriptorDTO> entry : processorToUpdate.getComponent().getConfig().getDescriptors().entrySet()) {
+            for (Map.Entry<String, PropertyDescriptorDTO> entry : processorToUpdate.getComponent().getConfig().getDescriptors().entrySet()) {
                 if (entry.getValue().getIdentifiesControllerService() != null) {
                     componentToPutInProc.getConfig().getProperties().remove(entry.getKey());
                 }

--- a/src/main/java/com/github/hermannpencole/nifi/config/utils/FunctionUtils.java
+++ b/src/main/java/com/github/hermannpencole/nifi/config/utils/FunctionUtils.java
@@ -2,20 +2,25 @@ package com.github.hermannpencole.nifi.config.utils;
 
 import com.github.hermannpencole.nifi.config.model.ConfigException;
 import com.github.hermannpencole.nifi.config.model.TimeoutException;
+import com.github.hermannpencole.nifi.swagger.client.model.ProcessGroupEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
-public class FunctionUtils {
+public final class FunctionUtils {
     /**
      * The logger.
      */
     private final static Logger LOG = LoggerFactory.getLogger(FunctionUtils.class);
+
+    private FunctionUtils() { }
 
     public static void runTimeout(Runnable function, int timeout) {
         java.util.concurrent.ExecutorService executor = Executors.newSingleThreadExecutor();
@@ -58,5 +63,11 @@ public class FunctionUtils {
 
     public static void runWhile(Supplier<Boolean> function, int interval, int timeout) {
         runTimeout(() -> runWhile(function, interval ), timeout);
+    }
+
+    public static Optional<ProcessGroupEntity> findByComponentName(List<ProcessGroupEntity> listGroup, String name) {
+        return listGroup.stream()
+                .filter(item -> item.getComponent().getName().trim().equals(name.trim()))
+                .findFirst();
     }
 }

--- a/src/test/java/com/github/hermannpencole/nifi/config/MainTest.java
+++ b/src/test/java/com/github/hermannpencole/nifi/config/MainTest.java
@@ -42,6 +42,8 @@ public class MainTest {
     @Mock
     private UpdateProcessorService updateProcessorServiceMock;
     @Mock
+    private CreateRouteService createRouteServiceMock;
+    @Mock
     private ExtractProcessorService extractProcessorServiceMock;
     @Mock
     private InformationService informationServiceMock;
@@ -119,6 +121,7 @@ public class MainTest {
                 bind(AccessService.class).toInstance(accessServiceMock);
                 bind(InformationService.class).toInstance(informationServiceMock);
                 bind(UpdateProcessorService.class).toInstance(updateProcessorServiceMock);
+                bind(CreateRouteService.class).toInstance(createRouteServiceMock);
                 bind(Integer.class).annotatedWith(Names.named("timeout")).toInstance(10);
                 bind(Integer.class).annotatedWith(Names.named("interval")).toInstance(10);
                 bind(Boolean.class).annotatedWith(Names.named("forceMode")).toInstance(false);
@@ -236,6 +239,5 @@ public class MainTest {
         Mockito.when(Guice.createInjector((AbstractModule)anyObject())).thenReturn(injector);
         doThrow(new ApiException()).when(accessServiceMock).addTokenOnConfiguration(false, null ,null);
         Main.main(new String[]{"-nifi","http://localhost:8080/nifi-api","-branch","\"root>N2\"","-conf","adr","-m","undeploy"});
-
     }
 }


### PR DESCRIPTION
_(description taken from documentation)_
Enable nifi-config to create connections between process groups by adding a `connections` JSON element to the configuration. The shortest route between the two process groups will be selected, with output and input ports named according to the connection's name used automatically, and created if they do not already exist. Note that it is only possible to connect to input and output ports, so this functionality is typically best used by including an input or output port already wired in to the template that is named the same as the connection.