### PR TITLE
#30 undeploy on stopping processors fix 

### DIFF
--- a/src/main/java/com/github/hermannpencole/nifi/config/service/ProcessorService.java
+++ b/src/main/java/com/github/hermannpencole/nifi/config/service/ProcessorService.java
@@ -75,6 +75,11 @@ public class ProcessorService {
 
     }
 
+    public int getThreadsCount(ProcessorEntity processor) throws ApiException {
+        ProcessorEntity loadedProcessor = processorsApi.getProcessor(processor.getId());
+        return loadedProcessor.getStatus().getAggregateSnapshot().getActiveThreadCount();
+    }
+
     /**
      * log the error reported by processor
      *


### PR DESCRIPTION
As a fix for the problem described in issue #30 , I propose to use the `processor.status.aggregateSnapshot.threadCount` parameter. It gives us an understanding of actual processor's thread count and might be used for monitoring of a "real" processor's state.

Proposed fix also respects the `timeout `& `interval `command-line parameters for the corresponding sleep/wait times.