### PR TITLE
[feature] allow specifying password using env variable

### DIFF
--- a/src/test/java/com/github/hermannpencole/nifi/config/MainTest.java
+++ b/src/test/java/com/github/hermannpencole/nifi/config/MainTest.java
@@ -69,10 +69,10 @@ public class MainTest {
         });
         //given
         PowerMockito.mockStatic(Guice.class);
-        Mockito.when(Guice.createInjector((AbstractModule)anyObject())).thenReturn(injector);
+        Mockito.when(Guice.createInjector((AbstractModule) anyObject())).thenReturn(injector);
 
-        Main.main(new String[]{"-nifi","http://localhost:8080/nifi-api","-branch","\"root>N2\"","-conf","adr","-m","undeploy"});
-        verify(templateServiceMock).undeploy(Arrays.asList("root","N2"));
+        Main.main(new String[]{"-nifi", "http://localhost:8080/nifi-api", "-branch", "\"root>N2\"", "-conf", "adr", "-m", "undeploy"});
+        verify(templateServiceMock).undeploy(Arrays.asList("root", "N2"));
     }
 
     @Test
@@ -91,10 +91,10 @@ public class MainTest {
         });
         //given
         PowerMockito.mockStatic(Guice.class);
-        Mockito.when(Guice.createInjector((AbstractModule)anyObject())).thenReturn(injector);
+        Mockito.when(Guice.createInjector((AbstractModule) anyObject())).thenReturn(injector);
 
-        Main.main(new String[]{"-nifi","https://localhost:8080/nifi-api","-branch","\"root>N2\"","-m","undeploy","-noVerifySsl"});
-        verify(templateServiceMock).undeploy(Arrays.asList("root","N2"));
+        Main.main(new String[]{"-nifi", "https://localhost:8080/nifi-api", "-branch", "\"root>N2\"", "-m", "undeploy", "-noVerifySsl"});
+        verify(templateServiceMock).undeploy(Arrays.asList("root", "N2"));
     }
 
     @Test
@@ -113,10 +113,10 @@ public class MainTest {
         });
         //given
         PowerMockito.mockStatic(Guice.class);
-        Mockito.when(Guice.createInjector((AbstractModule)anyObject())).thenReturn(injector);
+        Mockito.when(Guice.createInjector((AbstractModule) anyObject())).thenReturn(injector);
 
-        Main.main(new String[]{"-nifi","http://localhost:8080/nifi-api","-branch","\"root>N2\"","-conf","adr","-m","deployTemplate"});
-        verify(templateServiceMock).installOnBranch(Arrays.asList("root","N2"), "adr", false);
+        Main.main(new String[]{"-nifi", "http://localhost:8080/nifi-api", "-branch", "\"root>N2\"", "-conf", "adr", "-m", "deployTemplate"});
+        verify(templateServiceMock).installOnBranch(Arrays.asList("root", "N2"), "adr", false);
     }
 
     @Test
@@ -126,7 +126,7 @@ public class MainTest {
                 bind(AccessService.class).toInstance(accessServiceMock);
                 bind(InformationService.class).toInstance(informationServiceMock);
                 bind(UpdateProcessorService.class).toInstance(updateProcessorServiceMock);
-               // bind(ConnectionPortService.class).toInstance(createRouteServiceMock);
+                // bind(ConnectionPortService.class).toInstance(createRouteServiceMock);
                 bind(Integer.class).annotatedWith(Names.named("timeout")).toInstance(10);
                 bind(Integer.class).annotatedWith(Names.named("interval")).toInstance(10);
                 bind(Boolean.class).annotatedWith(Names.named("forceMode")).toInstance(false);
@@ -136,10 +136,37 @@ public class MainTest {
         });
         //given
         PowerMockito.mockStatic(Guice.class);
-        Mockito.when(Guice.createInjector((AbstractModule)anyObject())).thenReturn(injector);
+        Mockito.when(Guice.createInjector((AbstractModule) anyObject())).thenReturn(injector);
 
-        Main.main(new String[]{"-nifi","http://localhost:8080/nifi-api","-branch","\"root>N2\"","-conf","adr","-m","updateConfig","-user","user","-password","password"});
-        verify(updateProcessorServiceMock).updateByBranch(Arrays.asList("root","N2"), "adr",false);
+        Main.main(new String[]{"-nifi", "http://localhost:8080/nifi-api", "-branch", "\"root>N2\"", "-conf", "adr", "-m", "updateConfig", "-user", "user", "-password", "password"});
+        verify(updateProcessorServiceMock).updateByBranch(Arrays.asList("root", "N2"), "adr", false);
+    }
+
+    @Test
+    public void mainUpdateWithPasswordFromEnvTest() throws Exception {
+        PowerMockito.mockStatic(System.class);
+        Mockito.when(System.getenv(Main.ENV_NIFI_PASSWORD)).thenReturn("nifi_pass");
+
+        Injector injector = Guice.createInjector(new AbstractModule() {
+            protected void configure() {
+                bind(AccessService.class).toInstance(accessServiceMock);
+                bind(InformationService.class).toInstance(informationServiceMock);
+                bind(UpdateProcessorService.class).toInstance(updateProcessorServiceMock);
+                // bind(ConnectionPortService.class).toInstance(createRouteServiceMock);
+                bind(Integer.class).annotatedWith(Names.named("timeout")).toInstance(10);
+                bind(Integer.class).annotatedWith(Names.named("interval")).toInstance(10);
+                bind(Boolean.class).annotatedWith(Names.named("forceMode")).toInstance(false);
+                bind(Double.class).annotatedWith(Names.named("placeWidth")).toInstance(1200d);
+                bind(PositionDTO.class).annotatedWith(Names.named("startPosition")).toInstance(new PositionDTO());
+            }
+        });
+        //given
+        PowerMockito.mockStatic(Guice.class);
+        Mockito.when(Guice.createInjector((AbstractModule) anyObject())).thenReturn(injector);
+
+        Main.main(new String[]{"-nifi", "http://localhost:8080/nifi-api", "-branch", "\"root>N2\"", "-conf", "adr", "-m", "updateConfig", "-user", "user", "-password", "password"});
+        verify(updateProcessorServiceMock).updateByBranch(Arrays.asList("root", "N2"), "adr", false);
+        verify(accessServiceMock).addTokenOnConfiguration(false, "user", "nifi_pass");
     }
 
     @Test
@@ -158,9 +185,9 @@ public class MainTest {
         });
         //given
         PowerMockito.mockStatic(Guice.class);
-        Mockito.when(Guice.createInjector((AbstractModule)anyObject())).thenReturn(injector);
+        Mockito.when(Guice.createInjector((AbstractModule) anyObject())).thenReturn(injector);
 
-        Main.main(new String[]{"-nifi","http://localhost:8080/nifi-api","-conf","adr","-m","extractConfig", "-accessFromTicket"});
+        Main.main(new String[]{"-nifi", "http://localhost:8080/nifi-api", "-conf", "adr", "-m", "extractConfig", "-accessFromTicket"});
         verify(extractProcessorServiceMock).extractByBranch(Arrays.asList("root"), "adr", false);
     }
 
@@ -174,7 +201,7 @@ public class MainTest {
 
     @Test(expected = ConfigException.class)
     public void mainPrintUsageErrorBranchNotRootTest() throws Exception {
-        Main.main(new String[]{"-nifi","http://localhost:8080/nifi-api","-branch","\nifi/branch\"","-conf","adr","-m","undeploy"});
+        Main.main(new String[]{"-nifi", "http://localhost:8080/nifi-api", "-branch", "\nifi/branch\"", "-conf", "adr", "-m", "undeploy"});
     }
 
 
@@ -189,7 +216,7 @@ public class MainTest {
     @Test
     public void mainPrintUsageMandatoryWithoutModeTest() throws Exception {
         PowerMockito.mockStatic(System.class);
-        Main.main(new String[]{"-nifi","http://localhost:8080/nifi-api"});
+        Main.main(new String[]{"-nifi", "http://localhost:8080/nifi-api"});
         PowerMockito.verifyStatic();
         System.exit(1);
     }
@@ -197,7 +224,7 @@ public class MainTest {
     @Test
     public void mainPrintUsageMandatoryWithoutConfFileTest() throws Exception {
         PowerMockito.mockStatic(System.class);
-        Main.main(new String[]{"-nifi","http://localhost:8080/nifi-api", "-m","extractConfig"});
+        Main.main(new String[]{"-nifi", "http://localhost:8080/nifi-api", "-m", "extractConfig"});
         PowerMockito.verifyStatic();
         System.exit(1);
     }
@@ -205,15 +232,7 @@ public class MainTest {
     @Test
     public void mainPrintUsageModeUnknowTest() throws Exception {
         PowerMockito.mockStatic(System.class);
-        Main.main(new String[]{"-nifi","http://localhost:8080/nifi-api","-branch","\"root>N2\"","-conf","adr","-m","autre"});
-        PowerMockito.verifyStatic();
-        System.exit(1);
-    }
-
-    @Test
-    public void mainPrintUsageWithoutPasswordTest() throws Exception {
-        PowerMockito.mockStatic(System.class);
-        Main.main(new String[]{"-nifi","http://localhost:8080/nifi-api","-branch","\"root>N2\"","-conf","adr","-m","undeploy","-user","user"});
+        Main.main(new String[]{"-nifi", "http://localhost:8080/nifi-api", "-branch", "\"root>N2\"", "-conf", "adr", "-m", "autre"});
         PowerMockito.verifyStatic();
         System.exit(1);
     }
@@ -221,14 +240,14 @@ public class MainTest {
     @Test
     public void mainPrintUsageWithoutUserTest() throws Exception {
         PowerMockito.mockStatic(System.class);
-        Main.main(new String[]{"-nifi","http://localhost:8080/nifi-api","-branch","\"root>N2\"","-conf","adr","-m","undeploy","-password","pass"});
+        Main.main(new String[]{"-nifi", "http://localhost:8080/nifi-api", "-branch", "\"root>N2\"", "-conf", "adr", "-m", "undeploy", "-password", "pass"});
         PowerMockito.verifyStatic();
         System.exit(1);
     }
 
     @Test(expected = UnrecognizedOptionException.class)
     public void mainPrintUsage5Test() throws Exception {
-        Main.main(new String[]{"-nifi","http://localhost:8080/nifi-api", "-branch","\"root>N2\"","-conf","adr","-m","undeploy", "-userErr","user"});
+        Main.main(new String[]{"-nifi", "http://localhost:8080/nifi-api", "-branch", "\"root>N2\"", "-conf", "adr", "-m", "undeploy", "-userErr", "user"});
     }
 
     @Test(expected = ConfigException.class)
@@ -247,8 +266,8 @@ public class MainTest {
         });
         //given
         PowerMockito.mockStatic(Guice.class);
-        Mockito.when(Guice.createInjector((AbstractModule)anyObject())).thenReturn(injector);
-        doThrow(new ApiException()).when(accessServiceMock).addTokenOnConfiguration(false, null ,null);
-        Main.main(new String[]{"-nifi","http://localhost:8080/nifi-api","-branch","\"root>N2\"","-conf","adr","-m","undeploy"});
+        Mockito.when(Guice.createInjector((AbstractModule) anyObject())).thenReturn(injector);
+        doThrow(new ApiException()).when(accessServiceMock).addTokenOnConfiguration(false, null, null);
+        Main.main(new String[]{"-nifi", "http://localhost:8080/nifi-api", "-branch", "\"root>N2\"", "-conf", "adr", "-m", "undeploy"});
     }
 }


### PR DESCRIPTION
Hermann I would like to add an ability to specify Nifi password using system enviable.

We are running nifi-config in a shared environment and using command line parameter exposes password in a plain text when one issued:

$ **ps -ax | grep java**
Warning: bad syntax, perhaps a bogus '-'? See /usr/share/doc/procps-3.2.8/FAQ
6924 ? Sl 0:01 java -jar ../nifi-config/target/nifi-deploy-config-1.1.xxxx.jar -noVerifySsl -readTimeout 120000 -connectionTimeout 120000 -nifi https://xxxx:xxx/nifi-api -user svc-tap2-cicd **-password XXXXXX** -conf config.json -m updateConfig

