### PR TITLE
Provide optional flag to remove all controller services for a process group at undeploy stage.

### DIFF
--- a/src/main/java/com/github/hermannpencole/nifi/config/Main.java
+++ b/src/main/java/com/github/hermannpencole/nifi/config/Main.java
@@ -80,6 +80,7 @@ public class Main {
             options.addOption("placeWidth", true, "Width of place for installing group (default 1935 : 430 * (4 + 1/2) = 4 pro line)");
             options.addOption("startPosition", true, "Starting position for the place for installing group, format x,y (default : 0,0)");
             options.addOption("failOnDuplicateNames", false, "Fail if template contains duplicate processor names in extractConfig mode");
+            options.addOption("removeControllers", false, "Remove controller services from Processor Groups when undeploy(ing) NiFi templates");
 
             // parse the command line arguments
             CommandLine cmd = commandLineParser.parse(options, args);
@@ -109,6 +110,7 @@ public class Main {
                 Double placeWidth = cmd.hasOption("placeWidth") ? Double.valueOf(cmd.getOptionValue("placeWidth")) : DEFAULT_PLACEWIDTH;
                 String startPlace = cmd.hasOption("startPosition") ? cmd.getOptionValue("startPosition") : DEFAULT_PLACE;
                 Boolean forceMode = cmd.hasOption("force");
+                Boolean removeControllers = cmd.hasOption("removeControllers");
 
                 LOG.info(String.format("Starting config_nifi %s on mode %s", version, cmd.getOptionValue("m")));
                 String addressNifi = cmd.getOptionValue("n");
@@ -151,7 +153,7 @@ public class Main {
                     LOG.info("Template {} is installed on the group {}", fileConfiguration, branch);
                 } else {
                     TemplateService templateService = injector.getInstance(TemplateService.class);
-                    templateService.undeploy(branchList);
+                    templateService.undeploy(branchList, removeControllers);
                     LOG.info("The group {} is deleted", branch);
                 }
             }

--- a/src/main/java/com/github/hermannpencole/nifi/config/service/ControllerServicesService.java
+++ b/src/main/java/com/github/hermannpencole/nifi/config/service/ControllerServicesService.java
@@ -234,6 +234,16 @@ public class ControllerServicesService {
         }
     }
 
+    public void removeControllers(ProcessGroupFlowEntity processGroupFlow) {
+        // Controller Service must be disabled before it can be removed
+        disableController(processGroupFlow);
+        ControllerServicesEntity controllerServicesEntity = flowapi
+                .getControllerServicesFromGroup(processGroupFlow.getProcessGroupFlow().getId(), true, false);
+        List<ControllerServiceEntity> controllerServices = controllerServicesEntity.getControllerServices();
+        for (ControllerServiceEntity controllerService : controllerServices) {
+            remove(controllerService);
+        }
+    }
 
     public Map<String, RevisionDTO> getReferencingServices(String id, ControllerServiceReferencingComponentDTO.ReferenceTypeEnum type, String filteredState) throws ApiException {
         ControllerServiceEntity controllerServiceEntityFresh = getControllerServices(id);

--- a/src/main/java/com/github/hermannpencole/nifi/config/service/TemplateService.java
+++ b/src/main/java/com/github/hermannpencole/nifi/config/service/TemplateService.java
@@ -92,7 +92,7 @@ public class TemplateService {
         }
     }
 
-    public void undeploy(List<String> branch) throws ApiException {
+    public void undeploy(List<String> branch, Boolean removeControllers) throws ApiException {
         Optional<ProcessGroupFlowEntity> processGroupFlow = processGroupService.changeDirectory(branch);
         if (!processGroupFlow.isPresent()) {
             LOG.warn("cannot find " + Arrays.toString(branch.toArray()));
@@ -111,9 +111,13 @@ public class TemplateService {
             templatesApi.removeTemplate(templateInGroup.getId());
         }
 
-        //disable controllers
-        //TODO verify if must include ancestor and descendant
-        controllerServicesService.disableController(processGroupFlow.get());
+        if (removeControllers.booleanValue()) {
+            controllerServicesService.removeControllers(processGroupFlow.get());
+        } else {
+            //disable controllers
+            //TODO verify if must include ancestor and descendant
+            controllerServicesService.disableController(processGroupFlow.get());
+        }
 
         processGroupService.delete(processGroupFlow.get().getProcessGroupFlow().getId());
 

--- a/src/test/java/com/github/hermannpencole/nifi/config/MainTest.java
+++ b/src/test/java/com/github/hermannpencole/nifi/config/MainTest.java
@@ -55,6 +55,7 @@ public class MainTest {
 
     @Test
     public void mainUndeployTest() throws Exception {
+        Boolean removeControllers = false;
         Injector injector = Guice.createInjector(new AbstractModule() {
             protected void configure() {
                 bind(AccessService.class).toInstance(accessServiceMock);
@@ -72,11 +73,12 @@ public class MainTest {
         Mockito.when(Guice.createInjector((AbstractModule) anyObject())).thenReturn(injector);
 
         Main.main(new String[]{"-nifi", "http://localhost:8080/nifi-api", "-branch", "\"root>N2\"", "-conf", "adr", "-m", "undeploy"});
-        verify(templateServiceMock).undeploy(Arrays.asList("root", "N2"));
+        verify(templateServiceMock).undeploy(Arrays.asList("root", "N2"), removeControllers);
     }
 
     @Test
     public void mainHttpsUndeployTest() throws Exception {
+        Boolean removeControllers = false;
         Injector injector = Guice.createInjector(new AbstractModule() {
             protected void configure() {
                 bind(AccessService.class).toInstance(accessServiceMock);
@@ -94,7 +96,7 @@ public class MainTest {
         Mockito.when(Guice.createInjector((AbstractModule) anyObject())).thenReturn(injector);
 
         Main.main(new String[]{"-nifi", "https://localhost:8080/nifi-api", "-branch", "\"root>N2\"", "-m", "undeploy", "-noVerifySsl"});
-        verify(templateServiceMock).undeploy(Arrays.asList("root", "N2"));
+        verify(templateServiceMock).undeploy(Arrays.asList("root", "N2"), removeControllers);
     }
 
     @Test

--- a/src/test/java/com/github/hermannpencole/nifi/config/service/TemplateServiceTest.java
+++ b/src/test/java/com/github/hermannpencole/nifi/config/service/TemplateServiceTest.java
@@ -109,6 +109,7 @@ public class TemplateServiceTest {
 
     @Test
     public void undeployTest() throws ApiException {
+        Boolean removeControllers = false;
         List<String> branch = Arrays.asList("root", "elt1");
         ProcessGroupFlowEntity response = TestUtils.createProcessGroupFlowEntity("idProcessGroupFlow", "nameProcessGroupFlow");
         Optional<ProcessGroupFlowEntity> processGroupFlow = Optional.of(response);
@@ -143,7 +144,7 @@ public class TemplateServiceTest {
                 bind(PositionDTO.class).annotatedWith(Names.named("startPosition")).toInstance(new PositionDTO());
             }
         });
-        injector.getInstance(TemplateService.class).undeploy(branch);
+        injector.getInstance(TemplateService.class).undeploy(branch, removeControllers);
         verify(templatesApiMock).removeTemplate(template.getId());
         verify(processGroupServiceMock).stop(processGroupFlow.get());
         verify(processGroupServiceMock).delete(processGroupFlow.get().getProcessGroupFlow().getId());
@@ -151,10 +152,11 @@ public class TemplateServiceTest {
 
     @Test
     public void undeployNoExistTest() throws ApiException {
+        Boolean removeControllers = false;
         List<String> branch = Arrays.asList("root", "elt1");
         Optional<ProcessGroupFlowEntity> processGroupFlow = Optional.empty();
         when(processGroupServiceMock.changeDirectory(branch)).thenReturn(processGroupFlow);
-        templateService.undeploy(branch);
+        templateService.undeploy(branch, removeControllers);
         verify(flowApiMock, never()).getTemplates();
     }
 }


### PR DESCRIPTION
- Patch to remove controller services in undeploy mode
- Adding removeControllers argument to preserve original plugin functionality and provide the option to remove the controller services if required.